### PR TITLE
Fixed bash output in "Getting Started with Redline Smalltalk" link

### DIFF
--- a/discover/getting-started.html
+++ b/discover/getting-started.html
@@ -29,7 +29,7 @@ Follow these instructions to be executing Smalltalk code with Redline Smalltalk 
 You should see the following message from Redline Smalltalk:
 
 {% highlight bash %}
-hello world - from Redline Smalltalk.
+Hello World from Redline Smalltalk.
 {% endhighlight %}
 </p>
 
@@ -155,7 +155,7 @@ to follow these steps from your command prompt from within the 'redline-deploy' 
 You should see the following message from Redline Smalltalk:
 
 {% highlight bash %}
-hello world - from Redline Smalltalk.
+Hello World from Redline Smalltalk.
 {% endhighlight %}
 </p>
 


### PR DESCRIPTION
The bash output when running HelloWorld.st example was wrong. The correct is 'Hello World from Redline Smalltalk.'
