### PR TITLE
Fix example that has invalid command line for stic command

### DIFF
--- a/discover/getting-started.html
+++ b/discover/getting-started.html
@@ -147,7 +147,7 @@ to follow these steps from your command prompt from within the 'redline-deploy' 
 {% highlight bash %}
 >cd target/redline-deploy/
 >export REDLINE_HOME=`cd "$REDLINE_HOME" > /dev/null && pwd`
->./stic -s examples.st.redline.HelloWorld
+>./stic -s examples/ st.redline.HelloWorld
 {% endhighlight %}
 </p>
 


### PR DESCRIPTION
There is an error in example, the command provided won't run anything and prints error message with usage help. This fixes the example.
